### PR TITLE
Introduced logs stream logics

### DIFF
--- a/src/main/java/io/github/zanella/nomad/v1/client/ClientApi.java
+++ b/src/main/java/io/github/zanella/nomad/v1/client/ClientApi.java
@@ -1,7 +1,8 @@
 package io.github.zanella.nomad.v1.client;
 
-import io.github.zanella.nomad.v1.client.models.AllocationStats;
 import io.github.zanella.nomad.v1.client.models.AllocationFile;
+import io.github.zanella.nomad.v1.client.models.AllocationStats;
+import io.github.zanella.nomad.v1.client.models.LogStream;
 import io.github.zanella.nomad.v1.client.models.Stats;
 
 import java.util.List;
@@ -30,7 +31,7 @@ public interface ClientApi {
     @RequestLine("GET " + allocationFileStatsUrl)
     AllocationFile getAllocationFileStats(@Param("allocationId") String allocationId, @Param("path") String path);
 
-    String allocationFileContentUrl = "/v1/client/fs/cat/{allocationId}?path={path}";
+    String allocationFileContentUrl = "/v1/client/fs/readat/{allocationId}?path={path}&offset=0";
 
     @RequestLine("GET " + allocationFileContentUrl)
     byte[] getAllocationFileContent(@Param("allocationId") String allocationId, @Param("path") String path);
@@ -40,4 +41,11 @@ public interface ClientApi {
     @RequestLine("GET " + allocationFileContentOffsetUrl)
     byte[] getAllocationFileContent(@Param("allocationId") String allocationId, @Param("path") String path,
                                     @Param("offset") int offset, @Param("limit") int limit);
+
+    String allocationLogStreamUrl = "/v1/client/fs/logs/{allocationId}?task={task}&follow={follow}&type={type}&offset={offset}&origin={origin}&plain={plain}";
+
+    @RequestLine("GET " + allocationLogStreamUrl)
+    List<LogStream> getAllocationLogStreamsList(@Param("allocationId") String allocationId, @Param("task") String task,
+                                                @Param("follow") Boolean follow, @Param("type") LogStream.Type type,
+                                                @Param("offset") int offset, @Param("origin") LogStream.Origin origin, @Param("plain") Boolean plain);
 }

--- a/src/main/java/io/github/zanella/nomad/v1/client/models/LogStream.java
+++ b/src/main/java/io/github/zanella/nomad/v1/client/models/LogStream.java
@@ -1,0 +1,31 @@
+package io.github.zanella.nomad.v1.client.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor(suppressConstructorProperties = true)
+public class LogStream {
+
+    @JsonProperty("File") String file;
+
+    @JsonProperty("Offset") Double offset;
+
+    @JsonProperty("Data") String data;
+
+    @JsonProperty("FileEvent") String fileEvent;
+
+    public enum Type {
+
+        stdout, stderr;
+    }
+
+    public enum Origin {
+
+        start, end;
+    }
+}


### PR DESCRIPTION
Some parts are kind of ugly ([this](https://github.com/zanella/nomad-api/compare/master...smoope:master#diff-fc9b8c3541dbf42b12acd34b5a5ce7e4R122) for example), but unfortunatelly there is no another way to distinguish between streams and plain content APIs (i.e. both response with `text/plain` and `chunked`)