### PR TITLE
Updated Agent Members API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ compile "io.github.zanella.nomad:nomad-api:0.9"
 <dependency>
   <groupId>io.github.zanella.nomad</groupId>
   <artifactId>nomad-api</artifactId>
-  <version>0.9</version>
+  <version>0.10-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>io.github.zanella.nomad</groupId>
     <artifactId>nomad-api</artifactId>
     <packaging>jar</packaging>
-    <version>0.9</version>
+    <version>0.10-SNAPSHOT</version>
 
     <name>${project.artifactId}</name>
     <description>Java client for Nomad's HTTP API</description>

--- a/src/main/java/io/github/zanella/nomad/v1/agent/AgentApi.java
+++ b/src/main/java/io/github/zanella/nomad/v1/agent/AgentApi.java
@@ -3,6 +3,7 @@ package io.github.zanella.nomad.v1.agent;
 import feign.Param;
 import feign.RequestLine;
 import io.github.zanella.nomad.v1.agent.models.JoinResult;
+import io.github.zanella.nomad.v1.agent.models.Members;
 import io.github.zanella.nomad.v1.agent.models.Self;
 
 import java.util.List;
@@ -21,7 +22,7 @@ public interface AgentApi {
     String membersUrl = "/v1/agent/members";
 
     @RequestLine("GET " + membersUrl)
-    List<Self.Member> getMembers();
+    Members getMembers();
 
     String forceLeaveUrl = "/v1/agent/force-leave";
 

--- a/src/main/java/io/github/zanella/nomad/v1/agent/models/Members.java
+++ b/src/main/java/io/github/zanella/nomad/v1/agent/models/Members.java
@@ -1,0 +1,20 @@
+package io.github.zanella.nomad.v1.agent.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor(suppressConstructorProperties = true)
+public class Members {
+
+    @JsonProperty("ServerName") String serverName;
+    @JsonProperty("ServerRegion") String serverRegion;
+    @JsonProperty("ServerDC") String serverDc;
+
+    @JsonProperty("Members") List<Self.Member> member;
+}


### PR DESCRIPTION
This change adjusts the [`/v1/agent/members`](https://www.nomadproject.io/docs/http/agent-members.html) response as tested with Nomad 0.5.6.